### PR TITLE
Extends base fern client with eval utilities

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,2 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
+src/humanloop/eval_utils.py
+src/humanloop/client.py
+mypy.ini
+

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ client.prompts.log(
     messages=[{"role": "user", "content": "What really happened at Roswell?"}],
     inputs={"person": "Trump"},
     created_at=datetime.datetime.fromisoformat(
-        "2024-07-19 00:29:35.178000+00:00",
+        "2024-07-18 23:29:35.178000+00:00",
     ),
     provider_latency=6.5931549072265625,
     output_message={
@@ -88,7 +88,7 @@ async def main() -> None:
         ],
         inputs={"person": "Trump"},
         created_at=datetime.datetime.fromisoformat(
-            "2024-07-19 00:29:35.178000+00:00",
+            "2024-07-18 23:29:35.178000+00:00",
         ),
         provider_latency=6.5931549072265625,
         output_message={

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = ^src/humanloop/eval_utils\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "humanloop"
-version = "0.8.5"
+version = "0.8.6"
 description = ""
 readme = "README.md"
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "humanloop"
-version = "0.8.6"
+version = "0.8.6b0"
 description = ""
 readme = "README.md"
 authors = []

--- a/reference.md
+++ b/reference.md
@@ -56,7 +56,7 @@ client.prompts.log(
     messages=[{"role": "user", "content": "What really happened at Roswell?"}],
     inputs={"person": "Trump"},
     created_at=datetime.datetime.fromisoformat(
-        "2024-07-19 00:29:35.178000+00:00",
+        "2024-07-18 23:29:35.178000+00:00",
     ),
     provider_latency=6.5931549072265625,
     output_message={
@@ -6258,10 +6258,10 @@ client.flows.log(
     output="The patient is likely experiencing a myocardial infarction. Immediate medical attention is required.",
     trace_status="incomplete",
     start_time=datetime.datetime.fromisoformat(
-        "2024-07-08 22:40:35+00:00",
+        "2024-07-08 21:40:35+00:00",
     ),
     end_time=datetime.datetime.fromisoformat(
-        "2024-07-08 22:40:39+00:00",
+        "2024-07-08 21:40:39+00:00",
     ),
 )
 

--- a/src/humanloop/base_client.py
+++ b/src/humanloop/base_client.py
@@ -27,7 +27,7 @@ from .evaluations.client import AsyncEvaluationsClient
 from .logs.client import AsyncLogsClient
 
 
-class Humanloop:
+class BaseHumanloop:
     """
     Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
 
@@ -100,7 +100,7 @@ class Humanloop:
         self.logs = LogsClient(client_wrapper=self._client_wrapper)
 
 
-class AsyncHumanloop:
+class AsyncBaseHumanloop:
     """
     Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions.
 

--- a/src/humanloop/client.py
+++ b/src/humanloop/client.py
@@ -1,0 +1,50 @@
+import typing
+import os
+import httpx
+from functools import partial
+
+from .base_client import BaseHumanloop, AsyncBaseHumanloop
+from .environment import HumanloopEnvironment
+from .eval_utils import _run_eval
+
+
+class Humanloop(BaseHumanloop):
+    """
+    See docstring of BaseHumanloop.
+
+    This class extends the base client that contains the auto generated SDK functionality with custom evaluation utilities.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: typing.Optional[str] = None,
+        environment: HumanloopEnvironment = HumanloopEnvironment.DEFAULT,
+        api_key: typing.Optional[str] = os.getenv("HUMANLOOP_API_KEY"),
+        timeout: typing.Optional[float] = None,
+        follow_redirects: typing.Optional[bool] = True,
+        httpx_client: typing.Optional[httpx.Client] = None,
+    ):
+        """See docstring of BaseHumanloop.__init__(...)
+
+        This method extends the base client with evaluation utilities.
+        """
+        super().__init__(
+            base_url=base_url,
+            environment=environment,
+            api_key=api_key,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            httpx_client=httpx_client,
+        )
+        self.evaluations.run_local = partial(_run_eval, client=self)  # type: ignore[attr-defined]
+
+
+class AsyncHumanloop(AsyncBaseHumanloop):
+    """
+    See docstring of AsyncBaseHumanloop.
+
+    TODO: Add custom evaluation utilities for async case.
+    """
+
+    pass

--- a/src/humanloop/core/client_wrapper.py
+++ b/src/humanloop/core/client_wrapper.py
@@ -16,7 +16,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "humanloop",
-            "X-Fern-SDK-Version": "0.8.6",
+            "X-Fern-SDK-Version": "0.8.6b0",
         }
         headers["X-API-KEY"] = self.api_key
         return headers

--- a/src/humanloop/core/client_wrapper.py
+++ b/src/humanloop/core/client_wrapper.py
@@ -16,7 +16,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "humanloop",
-            "X-Fern-SDK-Version": "0.8.5",
+            "X-Fern-SDK-Version": "0.8.6",
         }
         headers["X-API-KEY"] = self.api_key
         return headers

--- a/src/humanloop/eval_utils.py
+++ b/src/humanloop/eval_utils.py
@@ -1,0 +1,560 @@
+"""
+Evaluation utils for the Humanloop SDK.
+
+This module provides a set of utilities to aid running Eval workflows on Humanloop
+where you are managing the runtime of your application in your code.
+
+Functions in this module should be accessed via the Humanloop client. They should
+not be called directly.
+"""
+import logging
+from datetime import datetime
+from functools import partial
+import inspect
+from logging import INFO
+from pydantic import BaseModel, ValidationError
+from typing import Callable, Sequence, Literal, Union, Optional, List, Dict, Tuple
+from typing_extensions import NotRequired, TypedDict
+import time
+import sys
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from .client import BaseHumanloop
+from .core.api_error import ApiError
+
+# We use TypedDicts for requests, which is consistent with the rest of the SDK
+from .requests import FlowKernelRequestParams as FlowDict
+from .requests import PromptKernelRequestParams as PromptDict
+from .requests import ToolKernelRequestParams as ToolDict
+from .requests import CreateDatapointRequestParams as DatapointDict
+from .requests import ExternalEvaluatorRequestParams as ExternalEvaluator
+from .requests import CodeEvaluatorRequestParams as CodeEvaluatorDict
+from .requests import LlmEvaluatorRequestParams as LLMEvaluatorDict
+from .requests import HumanEvaluatorRequestParams as HumanEvaluatorDict
+
+
+# Responses are Pydantic models
+from .types import FlowKernelRequest as FlowKernel
+from .types import BooleanEvaluatorStatsResponse as BooleanStats
+from .types import NumericEvaluatorStatsResponse as NumericStats
+from .types import UpdateDatesetAction as UpdateDatasetAction  # TODO: fix original type typo
+from .types import DatapointResponse as Datapoint
+from .types import (
+    EvaluationStats,
+    VersionStatsResponse,
+    EvaluatorArgumentsType,
+    EvaluatorReturnTypeEnum,
+    EvaluationResponse
+)
+
+# Setup logging
+logger = logging.getLogger(__name__)
+logger.setLevel(level=INFO)
+console_handler = logging.StreamHandler()
+logger.setLevel(INFO)
+formatter = logging.Formatter('%(message)s')
+console_handler.setFormatter(formatter)
+if not logger.hasHandlers():
+    logger.addHandler(console_handler)
+
+EvaluatorDict = Union[CodeEvaluatorDict, LLMEvaluatorDict, HumanEvaluatorDict, ExternalEvaluator]
+Version = Union[FlowDict, PromptDict, ToolDict, EvaluatorDict]
+FileType = Literal["flow", "prompt", "tool", "evaluator"]
+
+
+# ANSI escape codes for colors
+YELLOW = "\033[93m"
+CYAN = "\033[96m"
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+
+
+class Identifiers(TypedDict):
+    """Common identifiers for the objects required to run an Evaluation."""
+    id: NotRequired[str]
+    """The ID of the File on Humanloop."""
+    path: NotRequired[str]
+    """The path of the File on Humanloop."""
+
+
+class File(Identifiers, total=False):
+    """A File on Humanloop (Flow, Prompt, Tool, Evaluator)."""
+    type: NotRequired[FileType]
+    """The type of File this function relates to on Humanloop."""
+    version: NotRequired[Version]
+    """The contents uniquely define the version of the File on Humanloop"""
+    function: Callable
+    """The function being evaluated.
+    It will be called using your Dataset `inputs` as follows: `output = function(**datapoint.inputs)`.
+    If `messages` are defined in your Dataset, then `output = function(**datapoint.inputs, messages=datapoint.messages)`.
+    It should return a single string output. If not, you must provide a `custom_logger`.
+    """
+    custom_logger: NotRequired[Callable]
+    """function that logs the output of your function to Humanloop, replacing the default logging.
+    If provided, it will be called as follows:
+        ```
+        output = function(**datapoint.inputs).
+        log = custom_logger(client, output)
+        ```
+        Inside the custom_logger, you can use the Humanloop `client` to log the output of your function.
+        If not provided your pipline must return a single string.
+    """
+
+
+class RunDataset(Identifiers):
+    datapoints: Sequence[DatapointDict]
+    """The datapoints to map your function over to produce the outputs required by the evaluation."""
+    action: NotRequired[UpdateDatasetAction]
+    """How to update the Dataset given the provided Datapoints; 
+    `set` replaces the existing Datapoints and `add` appends to the existing Datapoints."""
+
+
+class RunEvaluator(Identifiers):
+    """The Evaluator to provide judgments for this Evaluation."""
+    args_type: NotRequired[EvaluatorArgumentsType]
+    """The type of arguments the Evaluator expects - only required for local Evaluators."""
+    return_type: NotRequired[EvaluatorReturnTypeEnum]
+    """The type of return value the Evaluator produces - only required for local Evaluators."""
+    function: NotRequired[Callable]
+    """The function to run on the logs to produce the judgment - only required for local Evaluators."""
+    custom_logger: NotRequired[Callable]
+    """optional function that logs the output judgment from your Evaluator to Humanloop, if provided, it will be called as follows:
+    ```
+    judgment = function(log_dict)
+    log = custom_logger(client, judgmemt)
+    ```
+    Inside the custom_logger, you can use the Humanloop `client` to log the judgment to Humanloop.
+    If not provided your function must return a single string and by default the code will be used to inform the version of the external Evaluator on Humanloop.
+    """
+    threshold: NotRequired[float]
+    """The threshold to check the Evaluator against. If the aggregate value of the Evaluator is below this threshold, the check will fail."""
+
+
+class EvaluatorCheck(BaseModel):
+    """Summary data for an Evaluator check."""
+    path: str
+    """The path of the Evaluator used in the check."""
+    improvement_check: bool
+    """Whether the latest version of your function has improved across the Dataset for a specific Evaluator."""
+    score: float
+    """The score of the latest version of your function for a specific Evaluator."""
+    delta: float
+    """The change in score since the previous version of your function for a specific Evaluator."""
+    threshold: Optional[float]
+    """The threshold to check the Evaluator against."""
+    threshold_check: Optional[bool]
+    """Whether the latest version has an average Evaluator result above a threshold."""
+
+
+def _run_eval(
+    client: BaseHumanloop,
+    file: File,
+    name: Optional[str],
+    dataset: RunDataset,
+    evaluators: Optional[Sequence[RunEvaluator]] = None,
+    # logs: typing.Sequence[dict] | None = None,
+    workers: int = 5,
+) -> List[EvaluatorCheck]:
+    """
+    Evaluate your function for a given `Dataset` and set of `Evaluators`
+
+    :param client: the Humanloop API client.
+    :param file: the Humanloop file being evaluated, including a function to run over the dataset.
+    :param name: the name of the Evaluation to run. If it does not exist, a new Evaluation will be created under your File.
+    :param dataset: the dataset to map your function over to produce the outputs required by the Evaluation.
+    :param evaluators: define how judgments are provided for this Evaluation.
+    :param workers: the number of threads to process datapoints using your function concurrently.
+    :return: per Evaluator checks.
+    """
+
+    # Get or create the file on Humanloop
+    version = file.pop("version", {})
+    try:
+        function_ = file.pop("function")
+    except KeyError as _:
+        raise ValueError("You must provide a function to run your Evaluation.")
+    try:
+        type_ = file.pop("type")
+    except KeyError as _:
+        # Default to flows if not type specified
+        type_ = "flow"
+        logger.warning("No type specified, defaulting to 'flow'.")
+    custom_logger = file.pop("custom_logger", None)
+    file_dict = {**file, **version}
+    if type_ == "flow":
+        # Be more lenient with Flow versions as they are arbitrary json
+        try:
+            FlowKernel.parse_obj(version)
+        except ValidationError:
+            flow_version = {"attributes": version}
+            file_dict = {**file, **flow_version}
+        hl_file = client.flows.upsert(**file_dict)
+    elif type_ == "prompt":
+        hl_file = client.prompts.upsert(**file_dict)
+    elif type_ == "tool":
+        hl_file = client.tools.upsert(**file_dict)
+    elif type_ == "evaluator":
+        hl_file = client.evaluators.upsert(**file_dict)
+    else:
+        raise NotImplementedError(f"Unsupported File type: {type_}")
+
+    # Upsert the Dataset
+    hl_dataset = client.datasets.upsert(**dataset)
+    hl_dataset = client.datasets.get(id=hl_dataset.id, include_datapoints=True)
+
+    # Upsert the local Evaluators; other Evaluators are just referenced by path
+    local_evaluators: List[RunEvaluator] = []
+    if evaluators:
+        for evaluator in evaluators:
+            # If a callable is provided for an Evaluator, we treat it as External
+            eval_function = evaluator.get("function")
+            if eval_function is not None:
+                local_evaluators.append(evaluator)
+                spec = ExternalEvaluator(
+                    arguments_type=evaluator["args_type"],
+                    return_type=evaluator["return_type"],
+                    attributes={"code": inspect.getsource(eval_function)},
+                    evaluator_type="external"
+                )
+                _ = client.evaluators.upsert(
+                    id=evaluator.get("id"),
+                    path=evaluator.get("path"),
+                    spec=spec
+                )
+
+    # Validate upfront that the local Evaluators and Dataset fit
+    requires_target = False
+    for local_evaluator in local_evaluators:
+        if local_evaluator["args_type"] == "target_required":
+            requires_target = True
+            break
+    if requires_target:
+        missing_target = 0
+        for datapoint in hl_dataset.datapoints:
+            if not datapoint.target:
+                missing_target += 1
+        if missing_target > 0:
+            raise ValueError(f"{missing_target} Datapoints have no target. A target is required for the Evaluator: {local_evaluator['path']}")
+
+    # Get or create the Evaluation based on the name
+    evaluation = None
+    try:
+        evaluation = client.evaluations.create(
+            name=name,
+            dataset={"file_id": hl_dataset.id},
+            evaluators=[{"path": e["path"]} for e in evaluators],
+            file={"id": hl_file.id},
+        )
+    except ApiError as error_:
+        # If the name exists, go and get it # TODO: Update API GET to allow querying by name and file.
+        if error_.status_code == 409:
+            evals = client.evaluations.list(file_id=hl_file.id, size=50)
+            for page in evals.iter_pages():
+                evaluation = next((e for e in page.items if e.name == name), None)
+        else:
+            raise error_
+        if not evaluation:
+            raise ValueError(f"Evaluation with name {name} not found.")
+
+    # Every run will generate a new batch of logs
+    batch_id = uuid.uuid4().hex[:10]  # ignore risk of collision
+    log_func = _get_log_func(
+        client=client,
+        type_=type_,
+        file_id=hl_file.id,
+        version_id=hl_file.version_id,
+        evaluation_id=evaluation.id,
+        batch_id=batch_id
+    )
+
+    # Define the function to execute your function in parallel and Log to Humanloop
+    def process_datapoint(datapoint: Datapoint):
+        start_time = datetime.now()
+        try:
+            if datapoint.messages:
+                output = function_(**datapoint.inputs, messages=datapoint.messages)
+            else:
+                output = function_(**datapoint.inputs)
+            if custom_logger:
+                log = function_(client=client, output=output)
+            else:
+                if not isinstance(output, str):
+                    raise ValueError("Your File function must return a string if you do not provide a custom logger.")
+                log = log_func(
+                    inputs=datapoint.inputs,
+                    output=output,
+                    source_datapoint_id=datapoint.id,
+                    start_time=start_time,
+                    end_time=datetime.now(),
+                )
+        except Exception as e:
+            log = log_func(
+                inputs=datapoint.inputs,
+                error=str(e),
+                source_datapoint_id=datapoint.id,
+                start_time=start_time,
+                end_time=datetime.now(),
+            )
+            logger.warning(msg=f"\nFile function failed for Datapoint: {datapoint.id}. \n Error: {str(e)}")
+
+        # Apply local Evaluators
+        for local_evaluator in local_evaluators:
+            try:
+                start_time = datetime.now()
+                eval_function = local_evaluator["function"]
+                if local_evaluator["args_type"] == "target_required":
+                    judgment = eval_function(log.dict(), datapoint.target)
+                else:
+                    judgment = eval_function(log.dict())
+
+                if local_evaluator.get("custom_logger", None):
+                    local_evaluator["custom_logger"](client=client, judgment=judgment)
+                else:
+                    # The API call will validate the judgment
+                    _ = client.evaluators.log(
+                        parent_id=log.id,
+                        id=local_evaluator.get("id"),
+                        path=local_evaluator.get("path"),
+                        judgment=judgment,
+                        start_time=start_time,
+                        end_time=datetime.now(),
+                    )
+            except Exception as e:
+                _ = client.evaluators.log(
+                    parent_id=log.id,
+                    path=local_evaluator.get("path"),
+                    id=local_evaluator.get("id"),
+                    error=str(e),
+                    start_time=start_time,
+                    end_time=datetime.now(),
+                )
+                logger.warning(f"\nEvaluator {local_evaluator['path']} failed with error {str(e)}")
+
+    # Execute the function and send the logs to Humanloop in parallel
+    total_datapoints = len(hl_dataset.datapoints)
+    logger.info(f"\n{CYAN}Navigate to your Evals:{RESET} {evaluation.url}")
+    logger.info(f"{CYAN}Version Id: {hl_file.version_id}{RESET}")
+    logger.info(f"{CYAN}Run Id: {batch_id}{RESET}")
+    logger.info(f"{CYAN}\nRunning function for File {hl_file.name} over the Dataset {hl_dataset.name}{RESET}")
+
+    completed_tasks = 0
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [
+            executor.submit(process_datapoint, datapoint)
+            for datapoint in hl_dataset.datapoints
+        ]
+        for _ in as_completed(futures):
+            completed_tasks += 1
+            _progress_bar(total_datapoints, completed_tasks)
+
+    # Wait for the Evaluation to complete then print the results
+    complete = False
+    stats = None
+    while not complete:
+        stats = client.evaluations.get_stats(id=evaluation.id)
+        logger.info(f"\r{stats.progress}")
+        complete = stats.status == "completed"
+        if not complete:
+            time.sleep(5)
+
+    # Print Evaluation results
+    logger.info(stats.report)
+
+    checks: List[EvaluatorCheck] = []
+    for evaluator in evaluators:
+        improvement_check, score, delta = check_evaluation_improvement(
+            evaluation=evaluation,
+            stats=stats,
+            evaluator_path=evaluator["path"],
+            batch_id=batch_id,
+        )
+        threshold_check = None
+        threshold = evaluator.get("threshold")
+        if threshold is not None:
+            threshold_check = check_evaluation_threshold(
+                evaluation=evaluation,
+                stats=stats,
+                evaluator_path=evaluator["path"],
+                threshold=threshold,
+                batch_id=batch_id,
+            )
+        checks.append(
+            EvaluatorCheck(
+                path=evaluator["path"],
+                improvement_check=improvement_check,
+                score=score,
+                delta=delta,
+                threshold=threshold,
+                threshold_check=threshold_check,
+            )
+        )
+    return checks
+
+
+def _get_log_func(
+    client: BaseHumanloop,
+    type_: FileType,
+    file_id: str,
+    version_id: str,
+    evaluation_id: str,
+    batch_id: str,
+) -> Callable:
+    """Returns the appropriate log function pre-filled with common parameters."""
+    log_request = {
+        # TODO: why does the Log `id` field refer to the file ID in the API?
+        #  Why are both `id` and `version_id` needed in the API?
+        "id": file_id,
+        "version_id": version_id,
+        "evaluation_id": evaluation_id,
+        "batch_id": batch_id,
+    }
+    if type_ == "flow":
+        return partial(client.flows.log, **log_request, trace_status="complete")
+    elif type_ == "prompt":
+        return partial(client.prompts.log, **log_request)
+    elif type_ == "evaluator":
+        return partial(client.evaluators.log, **log_request)
+    elif type_ == "tool":
+        return partial(client.tools.log, **log_request)
+    else:
+        raise NotImplementedError(f"Unsupported File version: {type_}")
+
+
+def get_score_from_evaluator_stat(stat: Union[NumericStats, BooleanStats]) -> Union[float, None]:
+    """Get the score from an Evaluator Stat."""
+    score = None
+    if isinstance(stat, BooleanStats):
+        if stat.total_logs:
+            score = round(stat.num_true / stat.total_logs, 2)
+    elif isinstance(stat, NumericStats):
+        score = round(stat.mean, 2)
+    else:
+        raise ValueError("Invalid Evaluator Stat type.")
+    return score
+
+
+def _progress_bar(total: int, progress: int):
+    """Simple progress bar for CLI with ETA."""
+
+    if total <= 0:
+        total = 1
+
+    if not hasattr(_progress_bar, 'start_time'):
+        _progress_bar.start_time = time.time()
+
+    bar_length = 40
+    block = int(round(bar_length * progress / total))
+    bar = "#" * block + '-' * (bar_length - block)
+
+    percentage = (progress / total) * 100
+    elapsed_time = time.time() - _progress_bar.start_time
+    time_per_item = elapsed_time / progress if progress > 0 else 0
+    eta = (total - progress) * time_per_item
+
+    progress_display = f"\r[{bar}] {progress}/{total}"
+    progress_display += f" ({percentage:.2f}%)"
+
+    if progress < total:
+        progress_display += f" | ETA: {int(eta)}s"
+    else:
+        progress_display += " | DONE"
+        _progress_bar.start_time = None
+
+    sys.stderr.write(progress_display)
+
+    if progress >= total:
+        sys.stderr.write("\n")
+
+
+def get_evaluator_stats_by_path(
+    stat: VersionStatsResponse, evaluation: EvaluationResponse
+) -> Dict[str, Union[NumericStats, BooleanStats]]:
+    """Get the Evaluator stats by path."""
+    # TODO: Update the API so this is not necessary
+    evaluators_by_id = {
+        evaluator.version.version_id: evaluator for evaluator in evaluation.evaluators
+    }
+    evaluator_stats_by_path = {
+        evaluators_by_id[evaluator_stat.evaluator_version_id].version.path: evaluator_stat
+        for evaluator_stat in stat.evaluator_version_stats
+    }
+    return evaluator_stats_by_path
+
+
+def check_evaluation_threshold(
+    evaluation: EvaluationResponse,
+    stats: EvaluationStats,
+    evaluator_path: str,
+    threshold: float,
+    batch_id: str,
+) -> bool:
+    """Checks if the latest version has an average Evaluator result above a threshold."""
+    # TODO: Update the API so this is not necessary
+    evaluator_stats_by_path = get_evaluator_stats_by_path(
+        stat=next((stat for stat in stats.version_stats if stat.batch_id == batch_id), None),
+        evaluation=evaluation
+    )
+    if evaluator_path in evaluator_stats_by_path:
+        evaluator_stat = evaluator_stats_by_path[evaluator_path]
+        score = get_score_from_evaluator_stat(stat=evaluator_stat)
+        if score >= threshold:
+            logger.info(
+                f"{GREEN}✅ Latest eval [{score}] above threshold [{threshold}] for evaluator {evaluator_path}.{RESET}"
+            )
+            return True
+        else:
+            logger.info(
+                f"{RED}❌ Latest score [{score}] below the threshold [{threshold}] for evaluator {evaluator_path}.{RESET}"
+            )
+            return False
+    else:
+        raise ValueError(f"Evaluator {evaluator_path} not found in the stats.")
+
+
+def check_evaluation_improvement(
+    evaluation: EvaluationResponse,
+    evaluator_path: str,
+    stats: EvaluationStats,
+    batch_id: str,
+) -> Tuple[bool, float, float]:
+    """
+    Check the latest version has improved across for a specific Evaluator.
+
+    :returns: A tuple of (improvement, latest_score, delta since previous score)
+    """
+    # TODO: Update the API so this is not necessary
+
+    latest_evaluator_stats_by_path = get_evaluator_stats_by_path(
+        stat=next((stat for stat in stats.version_stats if stat.batch_id == batch_id), None),
+        evaluation=evaluation
+    )
+    if len(stats.version_stats) == 1:
+        logger.info(
+            f"{YELLOW}⚠️ No previous versions to compare with.{RESET}"
+        )
+        return True, 0, 0
+
+    previous_evaluator_stats_by_path = get_evaluator_stats_by_path(
+        stat=stats.version_stats[-2],
+        evaluation=evaluation
+    )
+    if evaluator_path in latest_evaluator_stats_by_path and evaluator_path in previous_evaluator_stats_by_path:
+        latest_evaluator_stat = latest_evaluator_stats_by_path[evaluator_path]
+        previous_evaluator_stat = previous_evaluator_stats_by_path[evaluator_path]
+        latest_score = get_score_from_evaluator_stat(stat=latest_evaluator_stat)
+        previous_score = get_score_from_evaluator_stat(stat=previous_evaluator_stat)
+        diff = round(latest_score - previous_score, 2)
+        if diff >= 0:
+            logger.info(
+                f"{GREEN}✅ Improvement of [{diff}] for evaluator {evaluator_path}{RESET}"
+            )
+            return True, latest_score, diff
+        else:
+            logger.info(
+                f"{RED}❌ Regression of [{diff}] for evaluator {evaluator_path}{RESET}"
+            )
+            return False, latest_score, diff
+    else:
+        raise ValueError(f"Evaluator {evaluator_path} not found in the stats.")

--- a/src/humanloop/eval_utils.py
+++ b/src/humanloop/eval_utils.py
@@ -230,7 +230,7 @@ def _run_eval(
     hl_dataset = client.datasets.get(id=hl_dataset.id, include_datapoints=True)
 
     # Upsert the local Evaluators; other Evaluators are just referenced by `path` or `id`
-    local_evaluators: List[RunEvaluator] = []
+    local_evaluators: List[Evaluator] = []
     if evaluators:
         for evaluator in evaluators:
             # If a callable is provided for an Evaluator, we treat it as External

--- a/src/humanloop/flows/client.py
+++ b/src/humanloop/flows/client.py
@@ -197,10 +197,10 @@ class FlowsClient:
             output="The patient is likely experiencing a myocardial infarction. Immediate medical attention is required.",
             trace_status="incomplete",
             start_time=datetime.datetime.fromisoformat(
-                "2024-07-08 22:40:35+00:00",
+                "2024-07-08 21:40:35+00:00",
             ),
             end_time=datetime.datetime.fromisoformat(
-                "2024-07-08 22:40:39+00:00",
+                "2024-07-08 21:40:39+00:00",
             ),
         )
         """
@@ -1366,10 +1366,10 @@ class AsyncFlowsClient:
                 output="The patient is likely experiencing a myocardial infarction. Immediate medical attention is required.",
                 trace_status="incomplete",
                 start_time=datetime.datetime.fromisoformat(
-                    "2024-07-08 22:40:35+00:00",
+                    "2024-07-08 21:40:35+00:00",
                 ),
                 end_time=datetime.datetime.fromisoformat(
-                    "2024-07-08 22:40:39+00:00",
+                    "2024-07-08 21:40:39+00:00",
                 ),
             )
 

--- a/src/humanloop/prompts/client.py
+++ b/src/humanloop/prompts/client.py
@@ -236,7 +236,7 @@ class PromptsClient:
             messages=[{"role": "user", "content": "What really happened at Roswell?"}],
             inputs={"person": "Trump"},
             created_at=datetime.datetime.fromisoformat(
-                "2024-07-19 00:29:35.178000+00:00",
+                "2024-07-18 23:29:35.178000+00:00",
             ),
             provider_latency=6.5931549072265625,
             output_message={
@@ -2117,7 +2117,7 @@ class AsyncPromptsClient:
                 ],
                 inputs={"person": "Trump"},
                 created_at=datetime.datetime.fromisoformat(
-                    "2024-07-19 00:29:35.178000+00:00",
+                    "2024-07-18 23:29:35.178000+00:00",
                 ),
                 provider_latency=6.5931549072265625,
                 output_message={


### PR DESCRIPTION
This PR extends the auto-generated Humanloop client with additional utilities for running an Evaluation where the user manages their full application runtime.

Related fern docs for extending client with custom code: [Augment with custom code — Fern](https://buildwithfern.com/learn/sdks/features/augment-with-custom-code)

Specifically we add a method humanloop.evaluations.run_local(...) that takes details of a file destination on Humanloop, a user defined dataset, a user defined function to evaluator, a name for their Evaluation and details of their Evaluators.

This is invoked like so:

```python
from my_code import ask_question, load_dataset
checks = hl.evaluations.run(
    file={
        "path": "evals_demo/answer-flow",
        "type": "flow",
        "function": ask_question,
        "version": {"attributes": {"description": "Simple RAG, OpenAI + Chroma", "prompt": PROMPT}},
    },
    name="Staging CI",
    dataset={"path": "evals_demo/medqa-test", "datapoints": load_dataset()},
    evaluators=[
        {"path": "evals_demo/exact_match"},
        {"path": "evals_demo/levenshtein"},
        {"path": "evals_demo/reasoning", "threshold": 0.5},
    ],
    workers=4
)
```

With resulting output:
The resulting CLI output is
<img width="779" alt="Screenshot 2024-09-30 at 20 25 00" src="https://github.com/user-attachments/assets/f0881006-335c-46dd-b315-a607bcbf4dc1">
<img width="1146" alt="Screenshot 2024-09-30 at 20 25 37" src="https://github.com/user-attachments/assets/f4e37dc9-be28-47fa-94cc-bbcc6b323aec">

If the `file` or `dataset` does not yet exist on Humanloop, they will be created automatically, otherwise they will be updated appropriately. 

If the Evaluation exists for the file (based on the `name` provided) then a new run is added, otherwise a new Evaluation is automatically created.

Evaluators referenced by path (or id) must already exist. However, we've also provisionally added an affordance for local (or external) Evaluators:

```python
from my_code import ask_question, load_dataset
from my_evaluators import levenshtein_distance_optimized

checks = hl.evaluations.run(
    file={
        "path": "evals_demo/answer-flow",
        "type": "flow",
        "function": ask_question,
        "version": {"attributes": {"description": "Simple RAG, OpenAI + Chroma", "prompt": PROMPT}},
    },
    name="Staging CI",
    dataset={"path": "evals_demo/medqa-test", "datapoints": load_dataset()},
    evaluators=[
        {"path": "evals_demo/exact_match"},
        {"path": "evals_demo/levenshtein"},
        {"path": "evals_demo/reasoning", "threshold": 0.5},
        {
            "path": "evals_demo/levenshtein-optimized",
            "function": levenshtein_distance_optimized,
            "args_type": "target_required",
            "return_type": "number",
        }
    ],
    workers=4
)
``` 