### PR TITLE
Fix runs stats logging

### DIFF
--- a/src/humanloop/eval_utils.py
+++ b/src/humanloop/eval_utils.py
@@ -422,7 +422,11 @@ def _run_eval(
     while not complete:
         stats = client.evaluations.get_stats(id=evaluation.id)
         logger.info(f"\r{stats.progress}")
-        complete = stats.status == "completed"
+        run_stats = next(
+            (run_stats for run_stats in stats.run_stats if run_stats.run_id == run_id),
+            None,
+        )
+        complete = run_stats is not None and run_stats.status == "completed"
         if not complete:
             time.sleep(5)
 


### PR DESCRIPTION

- Run stats are now sorted with latest first; meaning the hardcoded [-2] index was wrong

Note that this still has issues as the printed table shows "Control" vs "Latest", whereas the calculated deltas are "Previous" to "Latest". which can be confusing.