### PR TITLE
Fix unsafe ContextVar lookup

### DIFF
--- a/src/humanloop/otel/exporter.py
+++ b/src/humanloop/otel/exporter.py
@@ -89,6 +89,7 @@ class HumanloopSpanExporter(SpanExporter):
                 if not is_evaluated_file(spans[0], evaluation_context):
                     evaluation_context = None
             except LookupError:
+                # No ongoing Evaluation happening
                 evaluation_context = None
             for span in spans:
                 if is_humanloop_span(span):


### PR DESCRIPTION
The .log statements of the subclients are overloaded to add run_id and source_datapoint_id attributes when the log is triggered by an eval_utils run. This fixes a bug where the overloaded log doesn't check if the variable was set, which would lead to logging failing whenever an evaluation is not happening.