### PR TITLE
fix eval run progress printing by clearing line

### DIFF
--- a/src/humanloop/eval_utils/run.py
+++ b/src/humanloop/eval_utils/run.py
@@ -196,7 +196,7 @@ class _SimpleProgressBar:
             time_per_item = elapsed_time / self._progress if self._progress > 0 else 0
             eta = (self._total - self._progress) * time_per_item
 
-            progress_display = f"\r[{bar}] {self._progress}/{self._total}"
+            progress_display = f"[{bar}] {self._progress}/{self._total}"
             progress_display += f" ({percentage:.2f}%)"
 
             if self._progress < self._total:
@@ -204,6 +204,8 @@ class _SimpleProgressBar:
             else:
                 progress_display += " | DONE"
 
+            sys.stderr.write("\r")  # Move the cursor to the beginning of the line
+            sys.stderr.write("\033[K")  # Clear the line from the cursor to the end
             sys.stderr.write(progress_display)
 
             if self._progress >= self._total:


### PR DESCRIPTION
fix the leftover "0s" after done

```
[########################################] 2/2 (100.00%) | DONE0s
```

Robin's pointed out that the progress bar completes quite quickly, but there's a significant wait after. (Which is confusing to a user because the default assumption is for the progress bar to cover the whole process, not just one part of it - i.e. why am i still waiting if the progress bar says "DONE").

I also looked into adding a "Completed generating Logs for N datapoints. Waiting for Evaluators to run and the Evaluation to complete..." print after the progress bar, but could not find a suitable place for this.
