### PR TITLE
use specified version id in run util

### DIFF
--- a/src/humanloop/eval_utils/run.py
+++ b/src/humanloop/eval_utils/run.py
@@ -409,7 +409,9 @@ def run_eval(
     run: EvaluationRunResponse = client.evaluations.create_run(
         id=evaluation.id,
         dataset={"version_id": hl_dataset.version_id},
+        version={"version_id": hl_file.version_id},
         orchestrated=False if function_ is not None else True,
+        use_existing_logs=False,
     )
     # Every Run will generate a new batch of Logs
     run_id = run.id


### PR DESCRIPTION
the run was previously being created without a fixed version ID (leading to runs with a dataset but no version).

this adds a Version to the create Run call.

(the previous implementation allowed for logging to other versions while logging to this Run with a custom logger, but since we're moving away from custom logger, we can now be more sure that the logs are associated to this version)