### PR TITLE
Add sleep to OTEL exporters

### DIFF
--- a/src/humanloop/otel/exporter/__init__.py
+++ b/src/humanloop/otel/exporter/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+import time
 import typing
 from queue import Empty as EmptyQueue
 from queue import Queue
@@ -129,7 +130,8 @@ class HumanloopSpanExporter(SpanExporter):
                 # Don't block or the thread will never be notified of the shutdown
                 thread_args = self._upload_queue.get(block=False)  # type: ignore
             except EmptyQueue:
-                # Wait for the another span to arrive
+                # Wait for another span to arrive
+                time.sleep(0.1)
                 continue
 
             span_to_export, eval_context_callback = thread_args


### PR DESCRIPTION
Infinite polling the export queue without a sleep was causing threads to take up a full core of CPU. Simple sleep fixes that.