### PR TITLE
Introduce async decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "humanloop"
 
 [tool.poetry]
 name = "humanloop"
-version = "0.8.40b5"
+version = "0.8.40b6"
 description = ""
 readme = "README.md"
 authors = []

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -n auto
+asyncio_mode = auto

--- a/src/humanloop/context.py
+++ b/src/humanloop/context.py
@@ -1,13 +1,14 @@
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-import threading
 from typing import Any, Callable, Generator, Literal, Optional
+
 from opentelemetry import context as context_api
 
 from humanloop.error import HumanloopRuntimeError
 from humanloop.otel.constants import (
-    HUMANLOOP_CONTEXT_EVALUATION,
     HUMANLOOP_CONTEXT_DECORATOR,
+    HUMANLOOP_CONTEXT_EVALUATION,
     HUMANLOOP_CONTEXT_TRACE_ID,
 )
 

--- a/src/humanloop/core/client_wrapper.py
+++ b/src/humanloop/core/client_wrapper.py
@@ -14,10 +14,10 @@ class BaseClientWrapper:
 
     def get_headers(self) -> typing.Dict[str, str]:
         headers: typing.Dict[str, str] = {
-            "User-Agent": "humanloop/0.8.40b5",
+            "User-Agent": "humanloop/0.8.40b6",
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "humanloop",
-            "X-Fern-SDK-Version": "0.8.40b5",
+            "X-Fern-SDK-Version": "0.8.40b6",
         }
         headers["X-API-KEY"] = self.api_key
         return headers

--- a/src/humanloop/decorators/flow.py
+++ b/src/humanloop/decorators/flow.py
@@ -1,6 +1,7 @@
 import logging
+import typing
 from functools import wraps
-from typing import Any, Awaitable, Callable, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Literal, Optional, TypeVar, Union, overload
 
 from opentelemetry.trace import Span, Tracer
 from typing_extensions import ParamSpec
@@ -39,87 +40,19 @@ def flow_decorator_factory(
     path: str,
     attributes: Optional[dict[str, Any]] = None,
 ):
-    flow_kernel = {"attributes": attributes or {}}
-
     def decorator(func: Callable[P, R]) -> Callable[P, Optional[R]]:
         decorator_path = path or func.__name__
         file_type = "flow"
+        flow_kernel = {"attributes": attributes or {}}
 
-        @wraps(func)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[R]:
-            span: Span
-            with set_decorator_context(
-                DecoratorContext(
-                    path=decorator_path,
-                    type="flow",
-                    version=flow_kernel,
-                )
-            ) as decorator_context:
-                with opentelemetry_tracer.start_as_current_span(HUMANLOOP_FLOW_SPAN_NAME) as span:  # type: ignore
-                    span.set_attribute(HUMANLOOP_FILE_PATH_KEY, decorator_path)
-                    span.set_attribute(HUMANLOOP_FILE_TYPE_KEY, file_type)
-                    trace_id = get_trace_id()
-                    func_args = bind_args(func, args, kwargs)
-
-                    # Create the trace ahead so we have a parent ID to reference
-                    init_log_inputs = {
-                        "inputs": {k: v for k, v in func_args.items() if k != "messages"},
-                        "messages": func_args.get("messages"),
-                        "trace_parent_id": trace_id,
-                    }
-                    this_flow_log: FlowLogResponse = client.flows._log(  # type: ignore [attr-defined]
-                        path=decorator_context.path,
-                        flow=decorator_context.version,
-                        log_status="incomplete",
-                        **init_log_inputs,
-                    )
-
-                    with set_trace_id(this_flow_log.id):
-                        func_output: Optional[R]
-                        log_output: Optional[str]
-                        log_error: Optional[str]
-                        log_output_message: Optional[ChatMessage]
-                        try:
-                            func_output = func(*args, **kwargs)
-                            if (
-                                isinstance(func_output, dict)
-                                and len(func_output.keys()) == 2
-                                and "role" in func_output
-                                and "content" in func_output
-                            ):
-                                log_output_message = func_output  # type: ignore [assignment]
-                                log_output = None
-                            else:
-                                log_output = process_output(func=func, output=func_output)
-                                log_output_message = None
-                            log_error = None
-                        except HumanloopRuntimeError as e:
-                            # Critical error, re-raise
-                            client.logs.delete(id=this_flow_log.id)
-                            span.record_exception(e)
-                            raise e
-                        except Exception as e:
-                            logger.error(f"Error calling {func.__name__}: {e}")
-                            log_output = None
-                            log_output_message = None
-                            log_error = str(e)
-                            func_output = None
-
-                        updated_flow_log = {
-                            "log_status": "complete",
-                            "output": log_output,
-                            "error": log_error,
-                            "output_message": log_output_message,
-                            "id": this_flow_log.id,
-                        }
-                        # Write the Flow Log to the Span on HL_LOG_OT_KEY
-                        write_to_opentelemetry_span(
-                            span=span,  # type: ignore [arg-type]
-                            key=HUMANLOOP_LOG_KEY,
-                            value=updated_flow_log,  # type: ignore
-                        )
-                        # Return the output of the decorated function
-                        return func_output  # type: ignore [return-value]
+        wrapper = _wrapper_factory(
+            client=client,
+            opentelemetry_tracer=opentelemetry_tracer,
+            func=func,
+            path=path,
+            flow_kernel=flow_kernel,
+            is_awaitable=False,
+        )
 
         wrapper.file = FileEvalConfig(  # type: ignore
             path=decorator_path,
@@ -139,87 +72,19 @@ def a_flow_decorator_factory(
     path: str,
     attributes: Optional[dict[str, Any]] = None,
 ):
-    flow_kernel = {"attributes": attributes or {}}
-
-    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[Optional[R]]]:
+    def decorator(func: Callable[P, Awaitable[R]]):
         decorator_path = path or func.__name__
         file_type = "flow"
+        flow_kernel = {"attributes": attributes or {}}
 
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[R]:
-            span: Span
-            with set_decorator_context(
-                DecoratorContext(
-                    path=decorator_path,
-                    type="flow",
-                    version=flow_kernel,
-                )
-            ) as decorator_context:
-                with opentelemetry_tracer.start_as_current_span(HUMANLOOP_FLOW_SPAN_NAME) as span:  # type: ignore
-                    span.set_attribute(HUMANLOOP_FILE_PATH_KEY, decorator_path)
-                    span.set_attribute(HUMANLOOP_FILE_TYPE_KEY, file_type)
-                    trace_id = get_trace_id()
-                    func_args = bind_args(func, args, kwargs)
-
-                    # Create the trace ahead so we have a parent ID to reference
-                    init_log_inputs = {
-                        "inputs": {k: v for k, v in func_args.items() if k != "messages"},
-                        "messages": func_args.get("messages"),
-                        "trace_parent_id": trace_id,
-                    }
-                    this_flow_log: FlowLogResponse = client.flows._log(  # type: ignore [attr-defined]
-                        path=decorator_context.path,
-                        flow=decorator_context.version,
-                        log_status="incomplete",
-                        **init_log_inputs,
-                    )
-
-                    with set_trace_id(this_flow_log.id):
-                        func_output: Optional[R]
-                        log_output: Optional[str]
-                        log_error: Optional[str]
-                        log_output_message: Optional[ChatMessage]
-                        try:
-                            func_output = await func(*args, **kwargs)
-                            if (
-                                isinstance(func_output, dict)
-                                and len(func_output.keys()) == 2
-                                and "role" in func_output
-                                and "content" in func_output
-                            ):
-                                log_output_message = func_output  # type: ignore [assignment]
-                                log_output = None
-                            else:
-                                log_output = process_output(func=func, output=func_output)
-                                log_output_message = None
-                            log_error = None
-                        except HumanloopRuntimeError as e:
-                            # Critical error, re-raise
-                            client.logs.delete(id=this_flow_log.id)
-                            span.record_exception(e)
-                            raise e
-                        except Exception as e:
-                            logger.error(f"Error calling {func.__name__}: {e}")
-                            log_output = None
-                            log_output_message = None
-                            log_error = str(e)
-                            func_output = None
-
-                        updated_flow_log = {
-                            "log_status": "complete",
-                            "output": log_output,
-                            "error": log_error,
-                            "output_message": log_output_message,
-                            "id": this_flow_log.id,
-                        }
-                        # Write the Flow Log to the Span on HL_LOG_OT_KEY
-                        write_to_opentelemetry_span(
-                            span=span,  # type: ignore [arg-type]
-                            key=HUMANLOOP_LOG_KEY,
-                            value=updated_flow_log,  # type: ignore
-                        )
-                        # Return the output of the decorated function
-                        return func_output  # type: ignore [return-value]
+        wrapper = _wrapper_factory(
+            client=client,
+            opentelemetry_tracer=opentelemetry_tracer,
+            func=func,
+            path=path,
+            flow_kernel=flow_kernel,
+            is_awaitable=True,
+        )
 
         wrapper.file = FileEvalConfig(  # type: ignore
             path=decorator_path,
@@ -231,3 +96,209 @@ def a_flow_decorator_factory(
         return wrapper
 
     return decorator
+
+
+@overload
+def _wrapper_factory(
+    client: "BaseHumanloop",
+    opentelemetry_tracer: Tracer,
+    func: Callable[P, Awaitable[R]],
+    path: str,
+    flow_kernel: dict[str, Any],
+    is_awaitable: Literal[True],
+) -> Callable[P, Awaitable[Optional[R]]]: ...
+
+
+@overload
+def _wrapper_factory(
+    client: "BaseHumanloop",
+    opentelemetry_tracer: Tracer,
+    func: Callable[P, R],
+    path: str,
+    flow_kernel: dict[str, Any],
+    is_awaitable: Literal[False],
+) -> Callable[P, Optional[R]]: ...
+
+
+def _wrapper_factory(  # type: ignore [misc]
+    client: "BaseHumanloop",
+    opentelemetry_tracer: Tracer,
+    func: Union[Callable[P, Awaitable[R]], Callable[P, R]],
+    path: str,
+    flow_kernel: dict[str, Any],
+    is_awaitable: bool,
+):
+    if is_awaitable:
+        func = typing.cast(Callable[P, Awaitable[R]], func)
+
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[R]:
+            span: Span
+            with set_decorator_context(
+                DecoratorContext(
+                    path=path,
+                    type="flow",
+                    version=flow_kernel,
+                )
+            ) as decorator_context:
+                with opentelemetry_tracer.start_as_current_span(HUMANLOOP_FLOW_SPAN_NAME) as span:  # type: ignore
+                    span, flow_log = _process_inputs(
+                        client=client,
+                        span=span,
+                        decorator_context=decorator_context,
+                        decorator_path=path,
+                        file_type="flow",
+                        func=func,
+                        args=args,
+                        kwargs=kwargs,
+                    )
+
+                    with set_trace_id(flow_log.id):
+                        func_output: Optional[R]
+                        try:
+                            func_output = await func(*args, **kwargs)  # type: ignore [misc]
+                            error = None
+                        except HumanloopRuntimeError as e:
+                            # Critical error, re-raise
+                            client.logs.delete(id=flow_log.id)
+                            span.record_exception(e)
+                            raise e
+                        except Exception as e:
+                            logger.error(f"Error calling {func.__name__}: {e}")
+                            error = e
+                            func_output = None
+
+                        _process_output(
+                            func=func,
+                            span=span,
+                            func_output=func_output,
+                            error=error,
+                            flow_log=flow_log,
+                        )
+
+                        # Return the output of the decorated function
+                        return func_output
+    else:
+        func = typing.cast(Callable[P, R], func)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[R]:
+            span: Span
+            with set_decorator_context(
+                DecoratorContext(
+                    path=path,
+                    type="flow",
+                    version=flow_kernel,
+                )
+            ) as decorator_context:
+                with opentelemetry_tracer.start_as_current_span(HUMANLOOP_FLOW_SPAN_NAME) as span:  # type: ignore
+                    span, flow_log = _process_inputs(
+                        client=client,
+                        span=span,
+                        decorator_context=decorator_context,
+                        decorator_path=path,
+                        file_type="flow",
+                        func=func,
+                        args=args,
+                        kwargs=kwargs,
+                    )
+
+                    with set_trace_id(flow_log.id):
+                        func_output: Optional[R]
+                        try:
+                            func_output = func(*args, **kwargs)
+                            error = None
+                        except HumanloopRuntimeError as e:
+                            # Critical error, re-raise
+                            client.logs.delete(id=flow_log.id)
+                            span.record_exception(e)
+                            raise e
+                        except Exception as e:
+                            logger.error(f"Error calling {func.__name__}: {e}")
+                            error = e
+                            func_output = None
+
+                        _process_output(
+                            func=func,
+                            span=span,
+                            func_output=func_output,
+                            error=error,
+                            flow_log=flow_log,
+                        )
+
+                        # Return the output of the decorated function
+                        return func_output
+
+    return wrapper
+
+
+def _process_inputs(
+    client: "BaseHumanloop",
+    span: Span,
+    decorator_context: DecoratorContext,
+    decorator_path: str,
+    file_type: str,
+    func: Callable[P, R],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+):
+    span.set_attribute(HUMANLOOP_FILE_PATH_KEY, decorator_path)
+    span.set_attribute(HUMANLOOP_FILE_TYPE_KEY, file_type)
+    trace_id = get_trace_id()
+    func_args = bind_args(func, args, kwargs)
+    # Create the trace ahead so we have a parent ID to reference
+    init_log_inputs = {
+        "inputs": {k: v for k, v in func_args.items() if k != "messages"},
+        "messages": func_args.get("messages"),
+        "trace_parent_id": trace_id,
+    }
+    flow_log: FlowLogResponse = client.flows._log(  # type: ignore [attr-defined]
+        path=decorator_context.path,
+        flow=decorator_context.version,
+        log_status="incomplete",
+        **init_log_inputs,
+    )
+    return span, flow_log
+
+
+def _process_output(
+    func: Union[Callable[P, R], Callable[P, Awaitable[R]]],
+    span: Span,
+    func_output: Optional[R],
+    error: Optional[Exception],
+    flow_log: FlowLogResponse,
+):
+    log_output: Optional[str]
+    log_error: Optional[str]
+    log_output_message: Optional[ChatMessage]
+    if not error:
+        if (
+            isinstance(func_output, dict)
+            and len(func_output.keys()) == 2
+            and "role" in func_output
+            and "content" in func_output
+        ):
+            log_output_message = func_output  # type: ignore [assignment]
+            log_output = None
+        else:
+            log_output = process_output(func=func, output=func_output)
+            log_output_message = None
+        log_error = None
+    else:
+        log_output = None
+        log_output_message = None
+        log_error = str(error)
+        func_output = None
+    updated_flow_log = {
+        "log_status": "complete",
+        "output": log_output,
+        "error": log_error,
+        "output_message": log_output_message,
+        "id": flow_log.id,
+    }
+    # Write the Flow Log to the Span on HL_LOG_OT_KEY
+    write_to_opentelemetry_span(
+        span=span,  # type: ignore [arg-type]
+        key=HUMANLOOP_LOG_KEY,
+        value=updated_flow_log,  # type: ignore
+    )

--- a/src/humanloop/decorators/flow.py
+++ b/src/humanloop/decorators/flow.py
@@ -1,9 +1,9 @@
 import logging
 from functools import wraps
-from typing import Any, Callable, Optional, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 from opentelemetry.trace import Span, Tracer
+from typing_extensions import ParamSpec
 
 from humanloop.base_client import BaseHumanloop
 from humanloop.context import (
@@ -12,18 +12,18 @@ from humanloop.context import (
     set_decorator_context,
     set_trace_id,
 )
-from humanloop.evals.run import HumanloopRuntimeError
-from humanloop.types.chat_message import ChatMessage
 from humanloop.decorators.helpers import bind_args
+from humanloop.evals.run import HumanloopRuntimeError
 from humanloop.evals.types import FileEvalConfig
 from humanloop.otel.constants import (
-    HUMANLOOP_FILE_TYPE_KEY,
-    HUMANLOOP_LOG_KEY,
     HUMANLOOP_FILE_PATH_KEY,
+    HUMANLOOP_FILE_TYPE_KEY,
     HUMANLOOP_FLOW_SPAN_NAME,
+    HUMANLOOP_LOG_KEY,
 )
 from humanloop.otel.helpers import process_output, write_to_opentelemetry_span
 from humanloop.requests import FlowKernelRequestParams as FlowDict
+from humanloop.types.chat_message import ChatMessage
 from humanloop.types.flow_log_response import FlowLogResponse
 
 logger = logging.getLogger("humanloop.sdk")
@@ -33,7 +33,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def flow(
+def flow_decorator_factory(
     client: "BaseHumanloop",
     opentelemetry_tracer: Tracer,
     path: str,
@@ -81,6 +81,106 @@ def flow(
                         log_output_message: Optional[ChatMessage]
                         try:
                             func_output = func(*args, **kwargs)
+                            if (
+                                isinstance(func_output, dict)
+                                and len(func_output.keys()) == 2
+                                and "role" in func_output
+                                and "content" in func_output
+                            ):
+                                log_output_message = func_output  # type: ignore [assignment]
+                                log_output = None
+                            else:
+                                log_output = process_output(func=func, output=func_output)
+                                log_output_message = None
+                            log_error = None
+                        except HumanloopRuntimeError as e:
+                            # Critical error, re-raise
+                            client.logs.delete(id=this_flow_log.id)
+                            span.record_exception(e)
+                            raise e
+                        except Exception as e:
+                            logger.error(f"Error calling {func.__name__}: {e}")
+                            log_output = None
+                            log_output_message = None
+                            log_error = str(e)
+                            func_output = None
+
+                        updated_flow_log = {
+                            "log_status": "complete",
+                            "output": log_output,
+                            "error": log_error,
+                            "output_message": log_output_message,
+                            "id": this_flow_log.id,
+                        }
+                        # Write the Flow Log to the Span on HL_LOG_OT_KEY
+                        write_to_opentelemetry_span(
+                            span=span,  # type: ignore [arg-type]
+                            key=HUMANLOOP_LOG_KEY,
+                            value=updated_flow_log,  # type: ignore
+                        )
+                        # Return the output of the decorated function
+                        return func_output  # type: ignore [return-value]
+
+        wrapper.file = FileEvalConfig(  # type: ignore
+            path=decorator_path,
+            type=file_type,  # type: ignore [arg-type, typeddict-item]
+            version=FlowDict(**flow_kernel),  # type: ignore
+            callable=wrapper,
+        )
+
+        return wrapper
+
+    return decorator
+
+
+def a_flow_decorator_factory(
+    client: "BaseHumanloop",
+    opentelemetry_tracer: Tracer,
+    path: str,
+    attributes: Optional[dict[str, Any]] = None,
+):
+    flow_kernel = {"attributes": attributes or {}}
+
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[Optional[R]]]:
+        decorator_path = path or func.__name__
+        file_type = "flow"
+
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[R]:
+            span: Span
+            with set_decorator_context(
+                DecoratorContext(
+                    path=decorator_path,
+                    type="flow",
+                    version=flow_kernel,
+                )
+            ) as decorator_context:
+                with opentelemetry_tracer.start_as_current_span(HUMANLOOP_FLOW_SPAN_NAME) as span:  # type: ignore
+                    span.set_attribute(HUMANLOOP_FILE_PATH_KEY, decorator_path)
+                    span.set_attribute(HUMANLOOP_FILE_TYPE_KEY, file_type)
+                    trace_id = get_trace_id()
+                    func_args = bind_args(func, args, kwargs)
+
+                    # Create the trace ahead so we have a parent ID to reference
+                    init_log_inputs = {
+                        "inputs": {k: v for k, v in func_args.items() if k != "messages"},
+                        "messages": func_args.get("messages"),
+                        "trace_parent_id": trace_id,
+                    }
+                    this_flow_log: FlowLogResponse = client.flows._log(  # type: ignore [attr-defined]
+                        path=decorator_context.path,
+                        flow=decorator_context.version,
+                        log_status="incomplete",
+                        **init_log_inputs,
+                    )
+
+                    with set_trace_id(this_flow_log.id):
+                        func_output: Optional[R]
+                        log_output: Optional[str]
+                        log_error: Optional[str]
+                        log_output_message: Optional[ChatMessage]
+                        try:
+                            func_output = await func(*args, **kwargs)
                             if (
                                 isinstance(func_output, dict)
                                 and len(func_output.keys()) == 2

--- a/src/humanloop/decorators/prompt.py
+++ b/src/humanloop/decorators/prompt.py
@@ -1,6 +1,7 @@
 import logging
+import typing
 from functools import wraps
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, Literal, TypeVar, Union, overload
 
 from typing_extensions import ParamSpec
 
@@ -15,20 +16,11 @@ R = TypeVar("R")
 
 def prompt_decorator_factory(path: str):
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
-        @wraps(func)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            with set_decorator_context(
-                DecoratorContext(
-                    path=path,
-                    type="prompt",
-                    version={
-                        # TODO: Implement a reverse-lookup of the template
-                        "template": None,
-                    },
-                )
-            ):
-                output = func(*args, **kwargs)
-                return output
+        wrapper = _wrapper_factory(
+            func=func,
+            path=path,
+            is_awaitable=False,
+        )
 
         wrapper.file = FileEvalConfig(  # type: ignore [attr-defined]
             path=path,
@@ -46,20 +38,11 @@ def prompt_decorator_factory(path: str):
 
 def a_prompt_decorator_factory(path: str):
     def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            with set_decorator_context(
-                DecoratorContext(
-                    path=path,
-                    type="prompt",
-                    version={
-                        # TODO: Implement a reverse-lookup of the template
-                        "template": None,
-                    },
-                )
-            ):
-                output = await func(*args, **kwargs)
-                return output
+        wrapper = _wrapper_factory(
+            func=func,
+            path=path,
+            is_awaitable=True,
+        )
 
         wrapper.file = FileEvalConfig(  # type: ignore [attr-defined]
             path=path,
@@ -73,3 +56,72 @@ def a_prompt_decorator_factory(path: str):
         return wrapper
 
     return decorator
+
+
+@overload
+def _wrapper_factory(
+    func: Callable[P, Awaitable[R]],
+    path: str,
+    is_awaitable: Literal[True],
+) -> Callable[P, Awaitable[R]]: ...
+
+
+@overload
+def _wrapper_factory(
+    func: Callable[P, R],
+    path: str,
+    is_awaitable: Literal[False],
+) -> Callable[P, R]: ...
+
+
+def _wrapper_factory(  # type: ignore [misc]
+    func: Union[Callable[P, Awaitable[R]], Callable[P, R]],
+    path: str,
+    is_awaitable: bool,
+):
+    """Create a wrapper function for a prompt-decorated function.
+
+    Args:
+        func: The function to decorate
+        path: The path to the prompt
+        is_awaitable: Whether the function is an async function
+
+    Returns:
+        A wrapper function that sets up the decorator context
+    """
+    if is_awaitable:
+        func = typing.cast(Callable[P, Awaitable[R]], func)
+
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            with set_decorator_context(
+                DecoratorContext(
+                    path=path,
+                    type="prompt",
+                    version={
+                        # TODO: Implement a reverse-lookup of the template
+                        "template": None,
+                    },
+                )
+            ):
+                output = await func(*args, **kwargs)  # type: ignore [misc]
+                return output  # type: ignore [return-value]
+    else:
+        func = typing.cast(Callable[P, R], func)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            with set_decorator_context(
+                DecoratorContext(
+                    path=path,
+                    type="prompt",
+                    version={
+                        # TODO: Implement a reverse-lookup of the template
+                        "template": None,
+                    },
+                )
+            ):
+                output = func(*args, **kwargs)  # type: ignore [misc]
+                return output  # type: ignore [return-value]
+
+    return wrapper

--- a/src/humanloop/decorators/prompt.py
+++ b/src/humanloop/decorators/prompt.py
@@ -1,8 +1,8 @@
-from functools import wraps
 import logging
+from functools import wraps
+from typing import Awaitable, Callable, TypeVar
 
 from typing_extensions import ParamSpec
-from typing import Callable, TypeVar
 
 from humanloop.context import DecoratorContext, set_decorator_context
 from humanloop.evals.types import FileEvalConfig
@@ -28,6 +28,37 @@ def prompt_decorator_factory(path: str):
                 )
             ):
                 output = func(*args, **kwargs)
+                return output
+
+        wrapper.file = FileEvalConfig(  # type: ignore [attr-defined]
+            path=path,
+            type="prompt",
+            version={  # type: ignore [typeddict-item]
+                "template": None,
+            },
+            callable=wrapper,
+        )
+
+        return wrapper
+
+    return decorator
+
+
+def a_prompt_decorator_factory(path: str):
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            with set_decorator_context(
+                DecoratorContext(
+                    path=path,
+                    type="prompt",
+                    version={
+                        # TODO: Implement a reverse-lookup of the template
+                        "template": None,
+                    },
+                )
+            ):
+                output = await func(*args, **kwargs)
                 return output
 
         wrapper.file = FileEvalConfig(  # type: ignore [attr-defined]

--- a/src/humanloop/evals/run.py
+++ b/src/humanloop/evals/run.py
@@ -122,7 +122,6 @@ CLIENT_TYPE = TypeVar(
 T = TypeVar("T")  # Add TypeVar T definition
 
 
-
 def print_error(message: str) -> None:
     """Print a formatted error message to stdout."""
     sys.stdout.write(f"{RED}{message}{RESET}")
@@ -459,7 +458,7 @@ def _resolve_file(client: "BaseHumanloop", file_config: FileEvalConfig) -> tuple
     except ApiError:
         if not version or not path or file_id:
             raise HumanloopRuntimeError(
-                "File does not exist on Humanloop. Please provide a `file.path` and a version to create a new version.",
+                "File does not exist on Humanloop. Please provide a `file.path` and a `file.version` to create a new version.",
             )
         return _upsert_file(file_config=file_config, client=client), callable or None
 

--- a/src/humanloop/otel/exporter/__init__.py
+++ b/src/humanloop/otel/exporter/__init__.py
@@ -1,23 +1,21 @@
 import logging
-
 import time
 import typing
 from queue import Empty as EmptyQueue
 from queue import Queue
 from threading import Thread
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
+import requests
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
-import requests
-from typing import Callable
 from humanloop.context import get_evaluation_context
 from humanloop.evals.run import HumanloopRuntimeError
 from humanloop.otel.constants import (
+    HUMANLOOP_FILE_PATH_KEY,
     HUMANLOOP_FILE_TYPE_KEY,
     HUMANLOOP_LOG_KEY,
-    HUMANLOOP_FILE_PATH_KEY,
 )
 from humanloop.otel.exporter.proto import serialize_span
 from humanloop.otel.helpers import (
@@ -26,7 +24,6 @@ from humanloop.otel.helpers import (
     read_from_opentelemetry_span,
     write_to_opentelemetry_span,
 )
-
 
 if typing.TYPE_CHECKING:
     from humanloop.client import Humanloop

--- a/src/humanloop/otel/exporter/proto.py
+++ b/src/humanloop/otel/exporter/proto.py
@@ -1,13 +1,15 @@
-from opentelemetry.proto.common.v1.common_pb2 import KeyValue, AnyValue, InstrumentationScope
+from google.protobuf.json_format import MessageToJson
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, InstrumentationScope, KeyValue
 from opentelemetry.proto.trace.v1.trace_pb2 import (
-    TracesData,
     ResourceSpans,
     ScopeSpans,
+    TracesData,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import (
     Span as ProtoBufferSpan,
 )
-from google.protobuf.json_format import MessageToJson
-
 from opentelemetry.sdk.trace import ReadableSpan
+
 from humanloop.otel.helpers import is_llm_provider_call
 
 

--- a/src/humanloop/otel/helpers.py
+++ b/src/humanloop/otel/helpers.py
@@ -5,7 +5,6 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.trace import SpanKind
 from opentelemetry.util.types import AttributeValue
 
-
 NestedDict = dict[str, Union["NestedDict", AttributeValue]]
 NestedList = list[Union["NestedList", NestedDict]]
 

--- a/src/humanloop/otel/processor.py
+++ b/src/humanloop/otel/processor.py
@@ -1,15 +1,14 @@
 import logging
 
-
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
 
 from humanloop.context import get_decorator_context, get_evaluation_context, get_trace_id
 from humanloop.otel.constants import (
     HUMANLOOP_FILE_KEY,
+    HUMANLOOP_FILE_PATH_KEY,
     HUMANLOOP_FILE_TYPE_KEY,
     HUMANLOOP_LOG_KEY,
-    HUMANLOOP_FILE_PATH_KEY,
 )
 from humanloop.otel.helpers import is_llm_provider_call
 

--- a/src/humanloop/overload.py
+++ b/src/humanloop/overload.py
@@ -264,7 +264,7 @@ def overload_client(
         def log_wrapper(self: T, **kwargs) -> LogResponseType:
             return _overload_log(self, file_syncer, use_local_files, **kwargs)
 
-        client.log = types.MethodType(log_wrapper, client)  # type: ignore [method-assign, union-attr, assignment]
+        client.log = types.MethodType(log_wrapper, client)  # type: ignore [method-assign]
 
     # Overload call method for Prompt and Agent clients
     if _get_file_type_from_client(client) in FileSyncer.SERIALIZABLE_FILE_TYPES:

--- a/src/humanloop/overload.py
+++ b/src/humanloop/overload.py
@@ -264,7 +264,7 @@ def overload_client(
         def log_wrapper(self: T, **kwargs) -> LogResponseType:
             return _overload_log(self, file_syncer, use_local_files, **kwargs)
 
-        client.log = types.MethodType(log_wrapper, client)  # type: ignore [method-assign, union-attr]
+        client.log = types.MethodType(log_wrapper, client)  # type: ignore [method-assign, union-attr, assignment]
 
     # Overload call method for Prompt and Agent clients
     if _get_file_type_from_client(client) in FileSyncer.SERIALIZABLE_FILE_TYPES:

--- a/src/humanloop/prompt_utils.py
+++ b/src/humanloop/prompt_utils.py
@@ -1,14 +1,12 @@
 import copy
-from typing import Any, Dict, List, Optional, TypeVar, Sequence
 import logging
-
 import re
+from typing import Any, Dict, List, Optional, Sequence, TypeVar
 
-from .requests.chat_message import ChatMessageParams
 from .prompts.requests.prompt_request_template import (
     PromptRequestTemplateParams,
 )
-
+from .requests.chat_message import ChatMessageParams
 
 logger = logging.getLogger(__name__)
 

--- a/tests/custom/integration/test_decorators.py
+++ b/tests/custom/integration/test_decorators.py
@@ -1,7 +1,8 @@
+import asyncio
 import time
 from typing import Any
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from tests.custom.integration.conftest import GetHumanloopClientFn
 
@@ -152,3 +153,100 @@ def test_flow_decorator_populates_output_message(
         flow_response = humanloop_client.files.retrieve_by_path(path=f"{sdk_test_dir}/test_flow_log_output_message")
         if flow_response is not None:
             humanloop_client.flows.delete(id=flow_response.id)
+
+
+async def test_async_flow_decorator(
+    get_humanloop_client: GetHumanloopClientFn,
+    sdk_test_dir: str,
+):
+    humanloop_client = get_humanloop_client()
+
+    @humanloop_client.a_flow(path=f"{sdk_test_dir}/test_async_flow")
+    async def my_flow(question: str) -> str:
+        return "baz!"
+
+    # THEN the output is the one expected
+    assert "baz!" in await my_flow("test")
+
+    # Wait for the flow and log to propagate to integration backend
+    await asyncio.sleep(3)
+
+    # THEN the file exists on Humanloop
+    flow_file_response = humanloop_client.files.retrieve_by_path(path=f"{sdk_test_dir}/test_async_flow")
+    assert flow_file_response is not None
+
+    # THEN a Log exists on the File
+    flow_logs_response = humanloop_client.logs.list(
+        file_id=flow_file_response.id,
+        page=1,
+        size=50,
+    )
+    assert flow_logs_response.items is not None and len(flow_logs_response.items) == 1
+    assert flow_logs_response.items[0].output == "baz!" and flow_logs_response.items[0].inputs == {"question": "test"}
+
+
+async def test_async_tool_decorator(
+    get_humanloop_client: GetHumanloopClientFn,
+    sdk_test_dir: str,
+):
+    humanloop_client = get_humanloop_client()
+
+    @humanloop_client.a_tool(path=f"{sdk_test_dir}/test_async_tool")
+    async def my_tool(question: str) -> str:
+        return "baz!"
+
+    assert hasattr(my_tool, "json_schema")
+
+    await my_tool("test")
+
+    # Wait for the flow and log to propagate to integration backend
+    await asyncio.sleep(3)
+
+    # THEN the file exists on Humanloop
+    tool_file_response = humanloop_client.files.retrieve_by_path(path=f"{sdk_test_dir}/test_async_tool")
+    assert tool_file_response is not None
+
+    # THEN a Log exists on the File
+    tool_logs_response = humanloop_client.logs.list(
+        file_id=tool_file_response.id,
+        page=1,
+        size=50,
+    )
+    assert tool_logs_response.items is not None and len(tool_logs_response.items) == 1
+    assert tool_logs_response.items[0].output == "baz!" and tool_logs_response.items[0].inputs == {"question": "test"}
+
+
+async def test_async_prompt_decorator(
+    get_humanloop_client: GetHumanloopClientFn,
+    openai_key: str,
+    sdk_test_dir: str,
+):
+    humanloop_client = get_humanloop_client()
+
+    @humanloop_client.a_prompt(path=f"{sdk_test_dir}/test_async_prompt")
+    async def my_prompt(question: str) -> str:
+        openai_client = AsyncOpenAI(api_key=openai_key)
+
+        response = await openai_client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": question}],
+        )
+
+        assert response.choices[0].message.content is not None
+        return response.choices[0].message.content
+
+    # THEN the output is the one expected
+    output = await my_prompt("What is the capital of the France?")
+    assert output is not None
+
+    # Wait for the prompt and log to propagate to integration backend
+    await asyncio.sleep(3)
+
+    # THEN the file exists on Humanloop
+    prompt_file_response = humanloop_client.files.retrieve_by_path(path=f"{sdk_test_dir}/test_async_prompt")
+    assert prompt_file_response is not None
+
+    # THEN a Log exists on the File
+    prompt_logs_response = humanloop_client.logs.list(file_id=prompt_file_response.id, page=1, size=50)
+    assert prompt_logs_response.items is not None and len(prompt_logs_response.items) == 1
+    assert prompt_logs_response.items[0].output_message.content == output  # type: ignore [union-attr]


### PR DESCRIPTION
* File decorators now have async equivalents: a_flow, a_tool and a_prompt
* They can be used in evals.run().
* We don't have a strong signal async decorators yet; thus the implementation places them on the sync client, leverages existing custom code for `evals.run()`, and makes 1-3 blocking calls per decorated function call.
Implementing a fully non-blocking version of the decorators implies rewriting the overload, OTEL exporter and eval run logic (from threaded to non-blocking), requiring a lot of effort.
* I propose scoping out the full reimplementation of custom functionality: The biggest non-blocking gains come from supporting async user code.
* OTEL offers the same API for spans, so I assume the context and span creation operations are in-memory and cheap
